### PR TITLE
Ensure emphasis ends with word boundary

### DIFF
--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ const rules = {
 		},
 	},
 	em: Object.assign({}, markdown.defaultRules.em, {
-		match: markdown.inlineRegex(/^\b_(\S(?:\\[\s\S]|[^\\])*?\S|\S)_(?!_)/),
+		match: markdown.inlineRegex(/^\b_(\S(?:\\[\s\S]|[^\\])*?\S|\S)_(?!_)\b/),
 		parse: (capture, parse) => {
 			return {
 				content: parse(capture[1]),

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-markdown",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "A markdown parser for Slack messages",
   "keywords": [
     "slack",
@@ -21,7 +21,7 @@
   "dependencies": {
     "escape-html": "^1.0.3",
     "node-emoji": "^1.10.0",
-    "simple-markdown": "^0.7.2"
+    "simple-markdown": "^0.7.3"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/test/single.test.js
+++ b/test/single.test.js
@@ -5,9 +5,14 @@ test("Should convert *text* to <strong>text</strong>", () => {
 		.toBe("This is a <strong>test</strong> with <strong>some bold</strong> text in it");
 });
 
-it("Should convert _text_ to <em>text</dem>", () => {
+it("Should convert _text_ to <em>text</em>", () => {
 	expect(markdown.toHTML("This is a _test_ with _some italicized_ text in it"))
 		.toBe("This is a <em>test</em> with <em>some italicized</em> text in it");
+});
+
+it("Should not convert inner_underscored_text to inner<em>underscored</em>text", () => {
+	expect(markdown.toHTML("This is a _test_ with some_italicized_text in it"))
+		.toBe("This is a <em>test</em> with some_italicized_text in it");
 });
 
 it("Should convert `text` to <code>text</code>", () => {


### PR DESCRIPTION
Added some unit tests for reported issues.
Updated simple-markdown to 0.7.3 to include security fix.

Fixes #3