### PR TITLE
Add support for more url protocols

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ const rules = {
 	newline: markdown.defaultRules.newline,
 	autolink: Object.assign({}, markdown.defaultRules.autolink, {
 		order: markdown.defaultRules.strong.order + 1,
-		match: markdown.inlineRegex(/^<((?:https?:\/\/|mailto:)[^|>]+)(\|([^>]*))?>/),
+		match: markdown.inlineRegex(/^<((?:(?:(?:ht|f)tps?|ssh|irc):\/\/|mailto:|tel:)[^|>]+)(\|([^>]*))?>/),
 		parse: (capture, parse, state) => {
 			const content = capture[3] ? parse(capture[3], state) : [{
 				type: "text",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-markdown",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A markdown parser for Slack messages",
   "keywords": [
     "slack",


### PR DESCRIPTION
Several links are not converted because their protocol doesn't match the regular expression.
We could even drop the protocol regex and allow any alphanumeric character but this will do for now.