### PR TITLE
Wrap emojis in a span

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,4 @@ toHTML("This *is* a _test_", options);
    - `date`: (`timestamp`: Timestamp, `format`: Format, `link`: Optional link, `fallback`: fallback string) Date mentions "<!date^timestamp^format^link|fallback>"
   - `cssModuleNames`: `object`, name mapping of CSS classes to custom ones
   - `noExtraSpanTags`: `boolean` (default: `false`) Disable the addition of extra span tags on slack-specific parsing
+  - `noExtraEmojiSpanTags`: `boolean` (default: `false`) Disable the addition of extra span tags around emojis

--- a/index.js
+++ b/index.js
@@ -48,11 +48,14 @@ const rulesUniversal = {
 				}
 			}
 			return {
+				isEmoji: !(e === ":" + code + ":"),
 				content: e,
 			};
 		},
-		html: (node) => {
-			return markdown.sanitizeText(node.content);
+		html: (node, output, state) => {
+			const content = markdown.sanitizeText(node.content);
+			if (!node.isEmoji) return content;
+			return htmlSlackTag(content, { class: "s-emoji" }, state);
 		},
 	},
 	text: Object.assign({}, markdown.defaultRules.text, {

--- a/index.js
+++ b/index.js
@@ -54,8 +54,8 @@ const rulesUniversal = {
 		},
 		html: (node, output, state) => {
 			const content = markdown.sanitizeText(node.content);
-			if (!node.isEmoji) return content;
-			return htmlSlackTag(content, { class: "s-emoji" }, state);
+			if (!node.isEmoji || state.noExtraEmojiSpanTags) return content;
+			return htmlTag("span", content, { class: "s-emoji" }, state);
 		},
 	},
 	text: Object.assign({}, markdown.defaultRules.text, {
@@ -326,6 +326,7 @@ function toHTML(source, opts) {
 		slackCallbacks: {},
 		cssModuleNames: {},
 		noExtraSpanTags: false,
+		noExtraEmojiSpanTags: false,
 	}, opts || {});
 	let _parser = parser;
 	let _htmlOutput = htmlOutput;
@@ -341,6 +342,7 @@ function toHTML(source, opts) {
 		cssModuleNames: options.cssModuleNames,
 		slackCallbacks: Object.assign({}, slackCallbackDefaults, options.slackCallbacks),
 		noExtraSpanTags: options.noExtraSpanTags,
+		noExtraEmojiSpanTags: options.noExtraEmojiSpanTags,
 	};
 
 	return _htmlOutput(_parser(source, state), state);

--- a/test/single.test.js
+++ b/test/single.test.js
@@ -99,6 +99,9 @@ it("Should emojify things", () => {
 
 	expect(markdown.toHTML("blah :fox_face: blah"))
 		.toBe("blah <span class=\"s-emoji\">🦊</span> blah");
+
+	expect(markdown.toHTML("blah :fox: blah", { noExtraEmojiSpanTags: true }))
+		.toBe("blah 🦊 blah");
 });
 
 it("Should leave unknown emojis alone", () => {

--- a/test/single.test.js
+++ b/test/single.test.js
@@ -95,10 +95,10 @@ it("Should handle block quotes with blank lines", () => {
 
 it("Should emojify things", () => {
 	expect(markdown.toHTML("blah :fox: blah"))
-		.toBe("blah 🦊 blah");
+		.toBe("blah <span class=\"s-emoji\">🦊</span> blah");
 
 	expect(markdown.toHTML("blah :fox_face: blah"))
-		.toBe("blah 🦊 blah");
+		.toBe("blah <span class=\"s-emoji\">🦊</span> blah");
 });
 
 it("Should leave unknown emojis alone", () => {


### PR DESCRIPTION
This wraps emojis in a `span` which allows customizing the styling of emojis to closer match the look and feel of the real Slack app by changing the size, padding, etc.