### PR TITLE
fix: Strike match

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,7 +159,7 @@ const rules = {
 		match: markdown.inlineRegex(/^\*(\S(?:\\[\s\S]|[^\\])*?\S|\S)\*(?!\*)/),
 	}),
 	strike: Object.assign({}, markdown.defaultRules.del, {
-		match: markdown.inlineRegex(/^~(\S(?:\\[\s\S]|[^\\])*?\S|\S)~(?!~)/),
+		match: markdown.inlineRegex(/^~(\w+)~/),
 	}),
 	inlineCode: markdown.defaultRules.inlineCode,
 	br: Object.assign({ }, markdown.defaultRules.br, {

--- a/test/single.test.js
+++ b/test/single.test.js
@@ -25,6 +25,11 @@ it("Should convert ~text~ to <del>text</del>", () => {
 		.toBe("<del>this</del>that");
 });
 
+it("Should convert ~this\\nthat~\\n and ~those~ to ~this<br>that~<br> and <del>those</del>", () => {
+	expect(markdown.toHTML("~this\nthat~\n and ~those~"))
+		.toBe("~this<br>that~<br> and <del>those</del>");
+});
+
 it("Should leave ~ test ~ alone", () => {
 	expect(markdown.toHTML("this ~ is a ~ test"))
 		.toBe("this ~ is a ~ test");


### PR DESCRIPTION
I am working on a case, where the output of match is not what I expected.

~Some text
Multi line ~
single ~~line~~

This is the output of slack, however when I use the library I get:
~~Some text
   Multi line~~
single ~~line~~

This pr fix this issue.
